### PR TITLE
include limits.h

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -21,6 +21,7 @@
 #include "extern.h"
 #include <openssl/x509v3.h>
 #include <assert.h>
+#include <limits.h>
 
 
 /*

--- a/src/poundctl.c
+++ b/src/poundctl.c
@@ -19,6 +19,7 @@
 #include "pound.h"
 #include "json.h"
 #include <assert.h>
+#include <limits.h>
 
 char *conf_name = POUND_CONF;
 char *socket_name;

--- a/src/svc.c
+++ b/src/svc.c
@@ -20,6 +20,7 @@
 #include "pound.h"
 #include "extern.h"
 #include "json.h"
+#include <limits.h>
 
 /*
  * basic hashing function, based on fmv

--- a/src/tmpl.c
+++ b/src/tmpl.c
@@ -26,6 +26,7 @@
 
 #include "pound.h"
 #include <assert.h>
+#include <limits.h>
 #include "json.h"
 
 static void


### PR DESCRIPTION
Include `limits.h` to avoid the following build failure:

```
poundctl.c: In function 'oi_getn':
poundctl.c:232:29: error: 'INT_MAX' undeclared (first use in this function)
  232 |   if (errno || n < 0 || n > INT_MAX)
      |                             ^~~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/4edfffcd5d4383c57947d97139331e0bf2cb6155