### PR TITLE
Prevent undefined NULL offset

### DIFF
--- a/src/mem.c
+++ b/src/mem.c
@@ -210,9 +210,14 @@ stringbuf_vprintf (struct stringbuf *sb, char const *fmt, va_list ap)
       size_t bufsize = sb->size - sb->len;
       ssize_t n;
       va_list aq;
+      char *sb_end = sb->base;
+      if (sb->len > 0)
+        {
+          sb_end += sb->len;
+        }
 
       va_copy (aq, ap);
-      n = vsnprintf (sb->base + sb->len, bufsize, fmt, aq);
+      n = vsnprintf (sb_end, bufsize, fmt, aq);
       va_end (aq);
 
       if (n < 0 || n >= bufsize || !memchr (sb->base + sb->len, '\0', n + 1))


### PR DESCRIPTION
When starting Pound with UBSan enabled, I get the following error:
```
mem.c:215:31: runtime error: applying zero offset to null pointer
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior mem.c:215:31 in
```

This is because the empty `stringbuf` is represented as `{.base=NULL, .len=0, ...}`, and `stringbuf_vprintf` offsets `sb->base` by `sb->len`. Thus, when `vprintf`ing the empty `stringbuf`, a `NULL` offset occurs, which is UB. This patch prevents that undefined behavior from happening.