### PR TITLE
Add missing \r when breaking up a long header in add_ssl_headers().

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -3326,7 +3326,7 @@ add_ssl_headers (POUND_HTTP *phttp)
       while (get_line (bio, buf, sizeof (buf)) == COPY_OK)
 	{
 	  if (i > 0)
-	    stringbuf_add_string (&sb, "\n\t");
+	    stringbuf_add_string (&sb, "\r\n\t");
 	  stringbuf_add_string (&sb, buf);
 	  i++;
 	}


### PR DESCRIPTION
Thanks for 0208af3, it solves  the "out of memory" syslog messages.

The fixed version was reporting 400/Bad Request. Since my backend is 80/http I used tcpdump to get traces of the 4.11 (working) and 4.13 (not working) headers. The difference is that 4.11 sends the X-SSL-certificate header all in one line but 4.13 breaks up this header into ~column 74 length lines. It does so with the sequence LF HT (0x0a, 0x09).  The lack of CR (0x0d) was making apache unhappy so here's a patch that adds it.