### PR TITLE
Reject requests with oversized chunk bodies

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -1436,8 +1436,11 @@ copy_chunks (BIO *cl, BIO *be, CONTENT_LENGTH *res_bytes, int no_write,
 	}
 
       if (buf[0])
-	logmsg (LOG_NOTICE, "(%"PRItid") unexpected after chunk \"%s\"",
-		POUND_TID (), buf);
+	{
+	  logmsg (LOG_NOTICE, "(%"PRItid") unexpected after chunk \"%s\"",
+		  POUND_TID (), buf);
+	  return HTTP_STATUS_BAD_REQUEST;
+	}    
       if (!no_write)
 	if (BIO_printf (be, "%s\r\n", buf) <= 0)
 	  {


### PR DESCRIPTION
This PR tightens the parsing of chunked HTTP requests by rejecting requests with oversized chunks. By oversized chunks, I mean chunks where the body exceeds the chunk size indicated in the chunk header. E.g.:

```
5
AAAAAXXX
0
```

Currently, pound logs this error, but 'allows it' (i.e. forwards the entire chunk as-is and lets the backend deal with it).

This behaviour is incorrect, and it can cause problems with some backends. Specifically, some HTTP parsers accept any 2-byte sequence as the line terminator of a chunk body (not checking that it is in fact a CRLF sequence). In such cases, pound and the backend will interpret the chunk boundaries differently, which can potentially lead to a request smuggling vulnerability.