### PR TITLE
Handle bodyless responses to HEAD requests and 304 responses from the…

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -4105,7 +4105,7 @@ backend_response (POUND_HTTP *phttp)
 	    case HEADER_TRANSFER_ENCODING:
 	      if ((val = http_header_get_value (hdr)) == NULL)
 		return HTTP_STATUS_INTERNAL_SERVER_ERROR;
-	      if (cs_locate_token (val, "chunked", NULL)
+	      if (cs_locate_token (val, "chunked", NULL) &&
 			  phttp->request.method != METH_HEAD &&
 			  phttp->response_code != 304)
 		{


### PR DESCRIPTION
… backend correctly when transfer-encoding chunked is set.

When a HEAD request receives a response from the backend with the header "Transfer-Encoding: chunked" set, pound waits for the body data. However, this data never arrives in responses to HEAD requests, so pound only responds to the client when the connection to the backend is terminated (e.g. due to a timeout). The same applies to 304 responses.

According to RFC9112 Chapter 6.1 (Transfer-Encoding: gzip, chunked), chunked is permitted for these two types, even though no body is sent, and some Tomcat and Tomee versions also send chunked on HEAD requests with a 404 response.
