### PR TITLE
Fix upd_session() does not work when using cookie for session control.

### DIFF
--- a/src/svc.c
+++ b/src/svc.c
@@ -1079,7 +1079,7 @@ upd_session (SERVICE *svc, HTTP_HEADER_LIST *headers, BACKEND *be)
       break;
 
     case SESS_COOKIE:
-      hname = "Cookie";
+      hname = "Set-Cookie";
       keyfun = key_cookie;
       break;
 


### PR DESCRIPTION
Sessions may not be maintained when cookie value changes.
The name for cookie in the HTTP response header is "set-cookie", not "cookie".