### PR TITLE
Fix typo ("oconf" -> "conf")

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2518,7 +2518,7 @@ parse_match_mode (CFG_ARG *arg, int dfl_re_type, int *gp_type, int *sp_flags,
 #ifdef HAVE_LIBPCRE
 	  *gp_type = GENPAT_PCRE;
 #else
-	  oconf_error_at_locus_range(&arg->locus,
+	  conf_error_at_locus_range(&arg->locus,
 				     "pound compiled without PCRE support");
 	  return -1;
 #endif


### PR DESCRIPTION
Fixes a typo that prevents building.

Without this patch, building gives this error:
```
config.c:2521:4: error: call to undeclared function 'oconf_error_at_locus_range'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
 2521 |           oconf_error_at_locus_range(&arg->locus,
      |           ^
  AR       libpound.a
1 error generated.
```

I'm pretty sure this is a typo. It should be `conf_error_at_locus_range`.